### PR TITLE
Allow foreman-tasks 1.0.0

### DIFF
--- a/foreman_probing.gemspec
+++ b/foreman_probing.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['test/**/*']
 
   s.add_dependency 'deface'
-  s.add_dependency 'foreman-tasks', '~> 0.9'
+  s.add_dependency 'foreman-tasks', '>= 0.9'
   s.add_dependency 'dynflow', '~> 1.0'
   # s.add_development_dependency 'rubocop'
   # s.add_development_dependency 'rdoc'


### PR DESCRIPTION
foreman-tasks 1.0.0 is not any revolution and only updated vendor to v3, meaning it requires Foreman 1.25, that's the reason for major bump. We may see that more often, so I suggest we drop the major version up limitation.